### PR TITLE
Install now works on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # from "curl ..."
 cmake-3.5.2
+cmake.msi
 
 # from "make install"
 bin
@@ -9,3 +10,4 @@ share
 # and so on...
 npm-debug.log
 node_modules
+install.log

--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@ Note that because `cmake` takes such a long time to download and compile,
 it is recommended that you install this package in global mode.
 
 Based on Stanley Gu's [cmake](https://github.com/stanleygu/cmake) for npm.
+
+## Installing on Windows
+When Windows is detected (via `process.platform === 'win32'`), CMake will be installed via MSI.
+
+This package:
+- will add cmake to the system PATH
+- requires a single interactive input: allowing escalation to administrator
+- can be debugged by setting `captureLogs` to true, enabling verbose logs
+- is safe to run if already installed

--- a/install.js
+++ b/install.js
@@ -1,0 +1,41 @@
+const execSync = require('child_process').execSync;
+const http = require('https');
+const fs = require('fs');
+
+// courtesy of https://stackoverflow.com/questions/11944932/how-to-download-a-file-with-node-js-without-using-third-party-libraries
+var download = function(url, dest, cb) {
+  var file = fs.createWriteStream(dest);
+  var request = http.get(url, function(response) {
+    response.pipe(file);
+    file.on('finish', function() {
+      file.close(cb);  // close() is async, call cb after close completes.
+    });
+  }).on('error', function(err) { // Handle errors
+    fs.unlink(dest); // Delete the file async. (But we don't check the result)
+    if (cb) cb(err.message);
+  });
+};
+
+if (process.platform === 'win32') {
+  let downloader = new Promise(function(resolve, reject) {
+    const captureLogs = false;
+    console.log('Downloading cmake 3.5.2 (Windows, x86)...');
+
+    download('https://cmake.org/files/v3.5/cmake-3.5.2-win32-x86.msi', 'cmake.msi', function () {
+      console.log('Download complete. Installing MSI...');
+      execSync('start /wait msiexec /i cmake.msi ADD_CMAKE_TO_PATH="System" /qb /norestart' + (captureLogs ? ' /l*v install.log' : ''));
+      resolve();
+    }, function (err) {
+      console.log('Error occurred during download: ' + err);
+      reject(err);
+    });
+  });
+
+  downloader
+    .then(function() { console.log('install.js has finished'); })
+    .catch(console.error);
+
+} else {
+  // TODO: this does not currently echo out to standard out :(
+  execSync("curl 'https://cmake.org/files/v3.5/cmake-3.5.2.tar.gz' -s -o - | tar xpfz - && D=`pwd` && cd cmake-3.5.2 && ./configure --prefix=$D && make && make install");
+}

--- a/msi-params
+++ b/msi-params
@@ -1,0 +1,26 @@
+---------------------------
+Windows Script Host
+---------------------------
+UpgradeCode  {8FFD1D72-B7F1-11E2-8EE5-00238BCA4991}
+ADD_CMAKE_TO_PATH  None
+WixUIRMOption  UseRM
+WIXUI_INSTALLDIR  INSTALL_ROOT
+ALLUSERS  1
+ARPNOMODIFY  1
+ARPPRODUCTICON  ProductIcon.ico
+ARPCOMMENTS  CMake is a cross-platform, open-source build system.
+ARPCONTACT  cmake@cmake.org
+ARPURLINFOABOUT  https://cmake.org
+Manufacturer  Kitware
+ProductCode  {39237166-D5CD-4F15-AC14-83287D8F372D}
+ProductLanguage  1033
+ProductName  CMake
+ProductVersion  3.5.2
+DefaultUIFont  WixUI_Font_Normal
+WixUI_Mode  InstallDir
+ErrorDialog  ErrorDlg
+SecureCustomProperties  INSTALL_ROOT;WIX_UPGRADE_DETECTED
+
+---------------------------
+OK
+---------------------------

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "cmake": "./bin/cmake"
   },
   "scripts": {
-    "preinstall": "curl 'https://cmake.org/files/v3.5/cmake-3.5.2.tar.gz' -s -o - | tar xpfz - && D=`pwd` && cd cmake-3.5.2 && ./configure --prefix=$D && make && make install"
+    "preinstall": "node ./install.js"
   }
 }


### PR DESCRIPTION
- npm's preinstall event will now execute a node script, install.js.
- install now works on Windows (has only been tested on Windows 10, x64)
